### PR TITLE
Ec bug fix payment type

### DIFF
--- a/BangazonAPI/Controllers/PaymentTypesController.cs
+++ b/BangazonAPI/Controllers/PaymentTypesController.cs
@@ -106,11 +106,11 @@ namespace BangazonAPI.Controllers
                 {
                     cmd.CommandText = @"DECLARE @PaymentTypeTemp Table(Id int);
 
-                        INSERT INTO PaymentType (AcctNumber, [Name], CustomerId)
-                        OUTPUT INSERTED.Id INTO @PaymentTypeTemp(Id)
-                        VALUES (@acctNumber, @name, @customerId)
+                                        INSERT INTO PaymentType (AcctNumber, [Name], CustomerId)
+                                        OUTPUT INSERTED.Id INTO @PaymentTypeTemp(Id)
+                                        VALUES (@acctNumber, @name, @customerId)
 
-                        SELECT TOP 1 @ID = Id FROM @PaymentTypeTemp";
+                                        SELECT TOP 1 @ID = Id FROM @PaymentTypeTemp";
 
                     SqlParameter outputParam = cmd.Parameters.Add("@ID", SqlDbType.Int);
                     outputParam.Direction = ParameterDirection.Output;
@@ -191,7 +191,11 @@ namespace BangazonAPI.Controllers
                     conn.Open();
                     using (SqlCommand cmd = conn.CreateCommand())
                     {
-                        cmd.CommandText = @"DELETE FROM PaymentType WHERE Id = @id";
+                        cmd.CommandText = @"UPDATE [Order]
+                                            SET PaymentTypeId = NULL
+                                            WHERE PaymentTypeId = @id;
+
+                                            DELETE FROM PaymentType WHERE Id = @id;";
                         cmd.Parameters.Add(new SqlParameter("@id", id));
 
                         int rowsAffected = await cmd.ExecuteNonQueryAsync();
@@ -201,9 +205,9 @@ namespace BangazonAPI.Controllers
                         }
                         else
                         {
-                            return new StatusCodeResult(StatusCodes.Status204NoContent);
+                            throw new Exception("No rows affected");
                         }
-                        throw new Exception("No rows affected");
+                        
                     }
                 }
             }


### PR DESCRIPTION
# Description

should be able to delete a payment type while updating orders now. include sql statements to input some dummy data.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# Testing Instructions

use whatever id number is generated for the new payment type to do the inserts, then run delete on that number. 

INSERT INTO PaymentType (AcctNumber, [Name], CustomerId)
VALUES (2345, 'banks', 2);

INSERT INTO [Order] (CustomerId, PaymentTypeId) VALUES (2, );
INSERT INTO [Order] (CustomerId, PaymentTypeId) VALUES (3, );
INSERT INTO [Order] (CustomerId, PaymentTypeId) VALUES (4, );


# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works
- [ ] I HAVE RUN ALLL MYYY TESSSTS!
